### PR TITLE
'Select a cateogy' now displays all posts

### DIFF
--- a/src/components/posts/PostList.js
+++ b/src/components/posts/PostList.js
@@ -21,8 +21,12 @@ export const PostList = () => {
     },[])
 
     const filterPostByCategory = (id) => {
-        getPostByCategory(id)
-            .then((res) => setPosts(res))
+        if (id === 0) {
+            getPosts().then(postData => setPosts(postData))
+        } else {
+            getPostByCategory(id)
+                .then((res) => setPosts(res))
+        }
     }
     
 


### PR DESCRIPTION
# Description

Fixed the category filter to display all posts when "Select a category" is selected.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I tested this in the browser by selecting a category, then selecting "Select a category".

- [ ] checkout into amd-category_bug_fix-client
- [ ] go into your browser and select a category, then select "Select a category".

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings